### PR TITLE
Add eleventyignore file

### DIFF
--- a/.eleventyignore
+++ b/.eleventyignore
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
Eleventy picks up the README as a page template and therefore generates a `README/index.html` file which is accessible at [gallery.contentful.com/README](https://gallery.contentful.com/README).

This PR adds an `.eleventyignore` file which instructs Eleventy not to generate a page for the README.